### PR TITLE
fixes setting array syntax

### DIFF
--- a/src/props.erl
+++ b/src/props.erl
@@ -144,10 +144,8 @@ do_set([{prop, Key}], _Value, NonProps) ->
 do_set([{index, Idx}], Value, List) when is_list(List) ->
     try
         {Prefix, Suffix} = case {Idx, List} of
-                               {1, []} ->
-                                   {[], []};
-                               {1, [_ | Suf]} ->
-                                   {[], Suf};
+                               {1, _} ->
+                                   {[], List};
                                _ ->
                                    lists:split(Idx - 1, List)
                            end,
@@ -155,7 +153,7 @@ do_set([{index, Idx}], Value, List) when is_list(List) ->
             [] ->
                 lists:append(Prefix, [Value]);
             [_ | Rest] ->
-                lists:append(Prefix, [Value], Rest)
+                lists:append([Prefix, [Value], Rest])
         end
     catch
         _:_ ->
@@ -193,7 +191,7 @@ do_set([{index, Idx} | Rest], Value, List) when is_list(List) ->
             lists:append(Prefix, [[]]);
         {[OldVal | End], _} ->
             Val = do_set(Rest, Value, OldVal),
-            lists:append(Prefix, [Val], End)
+            lists:append([Prefix, [Val], End])
     end;
 do_set([{index, Idx} | _Rest], _Value, NonList) ->
     throw(?INVALID_ACCESS_IDX(Idx, NonList)).

--- a/test/props_SUITE.erl
+++ b/test/props_SUITE.erl
@@ -10,6 +10,10 @@
          simple_set/1,
          multi_set/1,
          array_index_change/1,
+         array_index_change_first/1,
+         array_index_change_middle/1,
+         array_index_change_last/1,
+         array_object_field_change/1,
          create_implicit_props/1,
          create_implicit_array/1,
          create_implicit_index/1,
@@ -65,6 +69,10 @@ all() ->
      simple_set,
      multi_set,
      array_index_change,
+     array_index_change_first,
+     array_index_change_middle,
+     array_index_change_last,
+     array_object_field_change,
      create_implicit_props,
      create_implicit_array,
      create_implicit_index,
@@ -118,6 +126,26 @@ array_index_change(_Config) ->
     Src = {[{<<"a">>, [1]}]},
     Dst = {[{<<"a">>, [2]}]},
     Dst = props:set("a[1]", 2, Src).
+
+array_index_change_first(_Config) ->
+    Src = {[{<<"a">>, [1, 3, 5]}]},
+    Dst = {[{<<"a">>, [2, 3, 5]}]},
+    Dst = props:set("a[1]", 2, Src).
+
+array_index_change_middle(_Config) ->
+    Src = {[{<<"a">>, [1, 3, 5]}]},
+    Dst = {[{<<"a">>, [1, 2, 5]}]},
+    Dst = props:set("a[2]", 2, Src).
+
+array_index_change_last(_Config) ->
+    Src = {[{<<"a">>, [1, 3, 5]}]},
+    Dst = {[{<<"a">>, [1, 3, 2]}]},
+    Dst = props:set("a[3]", 2, Src).
+
+array_object_field_change(_Config) ->
+    Src = {[{<<"a">>, [{[{<<"b">>, 1}]}]}]},
+    Dst = {[{<<"a">>, [{[{<<"b">>, 2}]}]}]},
+    Dst = props:set("a[1].b", 2, Src).
 
 create_implicit_props(_Config) ->
     Src = {[]},


### PR DESCRIPTION
Existing handling of setting array indexes has a couple of issues. First, it calls a non-existent lists:append/3 in a couple of places. It also mishandles setting the first element of an array greater than length one. This adds tests that cover the problem spots in the code and fixes the problems.