### PR TITLE
Adding rebar3 support for compiling .peg files

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -15,3 +15,9 @@
          {git, "git://github.com/uwiger/edown.git", {tag, "0.8.4"}}},
         {neotoma, "1.7.4",
          {git, "git://github.com/seancribbs/neotoma.git", {tag, "1.7.4"}}}]}.
+
+{plugins, [rebar3_neotoma_plugin]}.
+
+{provider_hooks, [
+  {pre, [{compile, {neotoma, compile}}}]}
+]}.


### PR DESCRIPTION
When using this dependency in with `rebar3`, I noticed the `.peg`
files were not compiling and therefore the `props` library was
missing a beam required to function. By adding the `rebar3`
neotoma plugin and also adding the `provider_hook` to use the plugin
on compile, the `.peg` file is correctly compiled and the `props`
library works again.
