### PR TITLE
Fixing rebar3 support

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -19,5 +19,5 @@
 {plugins, [rebar3_neotoma_plugin]}.
 
 {provider_hooks, [
-  {pre, [{compile, {neotoma, compile}}}]}
+  {pre, [{compile, {neotoma, compile}}]}
 ]}.


### PR DESCRIPTION
There was an extra `}` provider hooks precompile directive which
was breaking the rebar.config. Removing that fixes the config and
should allow the application to compile again.
